### PR TITLE
Merge branch krys/tidy into main

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ docs-%:
 	$(MAKE) -C docs $*
 
 test: check-scy
-	$(PYTHON) -m pytest -n auto
+	$(PYTHON) -m pytest -n auto -rs
 
 test-cov: check-scy
 	$(PYTHON) -m pytest -n auto \

--- a/example/hpm-test/test_hpm.py
+++ b/example/hpm-test/test_hpm.py
@@ -134,4 +134,6 @@ class TestHPMClass:
                 "2or3.scy": [2, 3, 3, 3, 5],
                 "shortest.scy": [2, 4],
             }
-            assert scy_chunks == chunks[name]
+            assert len(scy_chunks) == len(chunks[name])
+            if scy_chunks != chunks[name]:
+                pytest.skip(f"expected {chunks[name]} chunks, got {scy_chunks}")

--- a/example/hpm-test/test_hpm.py
+++ b/example/hpm-test/test_hpm.py
@@ -136,4 +136,4 @@ class TestHPMClass:
             }
             assert len(scy_chunks) == len(chunks[name])
             if scy_chunks != chunks[name]:
-                pytest.skip(f"expected {chunks[name]} chunks, got {scy_chunks}")
+                pytest.skip(f"for {name}; expected {chunks[name]} chunks, got {scy_chunks}")

--- a/example/updn_cntr/test_updn_cntr.py
+++ b/example/updn_cntr/test_updn_cntr.py
@@ -219,7 +219,7 @@ class TestComplexClass:
         if "chunks" in test:
             assert len(scy_chunks) == len(test["chunks"])
             if scy_chunks != test["chunks"]:
-                pytest.skip(f"expected {test['chunks']} chunks, got {scy_chunks}")
+                pytest.skip(f"for {test['name']}; expected {test['chunks']} chunks, got {scy_chunks}")
 
 @pytest.mark.parametrize("test", [
         {"name":  "trace_root", "sequence": ["trace now:", "cover cp_4:"],

--- a/example/updn_cntr/test_updn_cntr.py
+++ b/example/updn_cntr/test_updn_cntr.py
@@ -217,7 +217,9 @@ class TestComplexClass:
 
     def test_chunks(self, test: "dict[str]", scy_chunks: "list[int]"):
         if "chunks" in test:
-            assert scy_chunks == test["chunks"]
+            assert len(scy_chunks) == len(test["chunks"])
+            if scy_chunks != test["chunks"]:
+                pytest.skip(f"expected {test['chunks']} chunks, got {scy_chunks}")
 
 @pytest.mark.parametrize("test", [
         {"name":  "trace_root", "sequence": ["trace now:", "cover cp_4:"],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.0.1"
 description = "Sequence of Covers with Yosys"
 
 dependencies = [
-    "yosys_mau"
+    "yosys_mau @ git+https://github.com/YosysHQ/mau@main"
 ]
 
 [project.scripts]

--- a/src/scy/scy.py
+++ b/src/scy/scy.py
@@ -145,6 +145,7 @@ class SCYTask():
         tree_task = tl.Task(on_run=run_tree)
         tree_task.depends_on(prep_task)
         tree_task.depends_on(dir_task)
+        tree_task[SCYTaskContext].task = None
 
         # setupmode skip
         if self.args.setupmode or self.args.dump_common:

--- a/src/scy/scy_sby_bridge.py
+++ b/src/scy/scy_sby_bridge.py
@@ -183,7 +183,7 @@ def parse_common_sby(common_task: TaskTree, sbycfg: SBYBridge, scycfg: SCYConfig
         sbycfg.script.extend([f"add -{cell['type']} {cell['lhs']} # line {line}",
                             f"setattr -set scy_line {line}  w:{cell['lhs']} %co c:$auto$add* %i"])
     for hdlname in enable_cells.keys():
-        select = f"w:*:*_EN c:{hdlname} %ci:+[EN] %i"
+        select = f"c:{hdlname} %ci:+[EN] c:{hdlname} %d"
         sbycfg.script.append(f"setattr -set scy_line 0 -set hdlname:{hdlname} 1 -set keep 1 {select}")
     if add_cells or enable_cells:
         add_log = "add_cells.log"


### PR DESCRIPTION
Fixed errors in SCY when using verific for code parsing.
Some of the tests expected specific cycle counts from the solver which aren't guaranteed to always be the same.  These have been downgraded to `skip` instead of `fail` and can safely be ignored.

@mmicko when I was testing this in the tabby cad suite I had some issues with included versions of pip and pytest being out of date, is it possible to update those?